### PR TITLE
Develop

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -3855,7 +3855,8 @@ public:
 #if defined(_ELPP_SYSLOG)
         // Register syslog logger and reconfigure format
         Logger* sysLogLogger = m_registeredLoggers->get(std::string(base::consts::kSysLogLoggerId));
-        sysLogLogger->configurations()->setGlobally(ConfigurationType::Format, "%level: %msg");
+        sysLogLogger->configurations()->setGlobally(ConfigurationType::Format, 
+                std::string( "%level: %msg") );
         sysLogLogger->reconfigure();
 #else
         _ELPP_UNUSED(base::consts::kSysLogLoggerId);


### PR DESCRIPTION
This series of changes clean ups warnings when compiling with the intel c++ compiler with -Wall.  Some of the changes are trivial, some are annoying.  I understand if you want to reject some of the uglier fixes.  If there are nicer ways to fix those warnings, let me know and I can make another patch with different fixes.

I would like to use easylogging, but I always build with -Wall, and in the current state the warnings are so numerous that it is not possible.  
