### PR TITLE
Mutex should not be copyable.

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -910,7 +910,7 @@ namespace threading {
 #   if !_ELPP_USE_STD_THREADING
 namespace internal {
 /// @brief A mutex wrapper for compiler that dont yet support std::mutex
-class Mutex {
+class Mutex : base::NoCopy {
 public:
     Mutex(void) {
 #   if _ELPP_OS_UNIX


### PR DESCRIPTION
I also created the v8_branch and fixed it there too (tagged with v8.92). I cannot use C++11, so I guess I'm stuck at the v8 version. Note that for this reason, I could only test v8.92, not the master version...
