### PR TITLE
Unicode output on Windows is now converted from UTF-16 to UTF-8.

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -289,6 +289,7 @@
 #include <cstdarg>
 #if defined(_ELPP_UNICODE)
 #   include <locale>
+#   include <codecvt>
 #endif  // defined(_ELPP_UNICODE)
 #if _ELPP_STACKTRACE
 #   include <cxxabi.h>
@@ -1048,6 +1049,10 @@ public:
             base::type::fstream_t::out | base::type::fstream_t::app);
 #if defined(_ELPP_UNICODE)
         std::locale elppUnicodeLocale("");
+#if _ELPP_OS_WINDOWS
+        std::locale elppUnicodeLocaleWindows(elppUnicodeLocale, new std::codecvt_utf8_utf16<wchar_t>);
+        elppUnicodeLocale = elppUnicodeLocaleWindows;
+#endif
         fs->imbue(elppUnicodeLocale);
 #endif  // defined(_ELPP_UNICODE)
         if (fs->is_open()) {


### PR DESCRIPTION
This fixes the problem seen in issue #182.

After digging through the fstream code, the output stops because a call to wcrtomb fails deep within one of the system headers. The wcrtomb code succeeds for regular characters, but fails for foreign characters (I believe this is locale dependent, so the exact conditions under which it succeeds/fails will depend on your system).

By switching to codecvt_utf8_utf16, the call to wcrtomb is avoided entirely, and the output will succeed, provided the string can be converted from UTF-16 to UTF-8.
