### PR TITLE
New option called ToStandardError

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -304,7 +304,7 @@
 #   include <direct.h>
 #   include <Windows.h>
 #   if defined(WIN32_LEAN_AND_MEAN)
-#      include <winsock2.h>
+#      include <winsock.h>
 #   endif // defined(WIN32_LEAN_AND_MEAN)
 #endif  // _ELPP_OS_UNIX
 #include <string>


### PR DESCRIPTION
I needed an option to direct logs to cerr in order to finish replacing boost logging. If this is a feature that you want to include in the project I can update the readme also (and maybe enable it by default).
