### PR TITLE
Changing default format from a more localized %d/%M/%Y to ISO 8601 standard

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -749,8 +749,8 @@ namespace consts {
     static const char* kMonths[12]                      =      { "January", "February", "March", "Apri", "May", "June", "July", "August",
             "September", "October", "November", "December" };
     static const char* kMonthsAbbrev[12]                =      { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
-    static const char* kDefaultDateTimeFormat           =      "%d/%M/%Y %H:%m:%s,%g";
-    static const char* kDefaultDateTimeFormatInFilename =      "%d-%M-%Y_%H-%m";
+    static const char* kDefaultDateTimeFormat           =      "%Y-%M-%d %H:%m:%s,%g";
+    static const char* kDefaultDateTimeFormatInFilename =      "%Y-%M-%d_%H-%m";
     static const int kYearBase                          =      1900;
     static const char* kAm                              =      "AM";
     static const char* kPm                              =      "PM";

--- a/test/log-format-resolution-test.h
+++ b/test/log-format-resolution-test.h
@@ -24,17 +24,17 @@ TEST(LogFormatResolutionTest, DefaultFormat) {
     LogFormat defaultFormat(Level::Info, ELPP_LITERAL("%logger %datetime %thread"));
     EXPECT_EQ(ELPP_LITERAL("%logger %datetime %thread"), defaultFormat.userFormat());
     EXPECT_EQ(ELPP_LITERAL("%logger %datetime %thread"), defaultFormat.format());
-    EXPECT_EQ("%d/%M/%Y %H:%m:%s,%g", defaultFormat.dateTimeFormat());
+    EXPECT_EQ("%Y-%M-%d %H:%m:%s,%g", defaultFormat.dateTimeFormat());
 
     LogFormat defaultFormat2(Level::Info, ELPP_LITERAL("%logger %datetime %thread"));
     EXPECT_EQ(ELPP_LITERAL("%logger %datetime %thread"), defaultFormat2.userFormat());
     EXPECT_EQ(ELPP_LITERAL("%logger %datetime %thread"), defaultFormat2.format());
-    EXPECT_EQ("%d/%M/%Y %H:%m:%s,%g", defaultFormat2.dateTimeFormat());
+    EXPECT_EQ("%Y-%M-%d %H:%m:%s,%g", defaultFormat2.dateTimeFormat());
 
     LogFormat defaultFormat4(Level::Verbose, ELPP_LITERAL("%logger %level-%vlevel %datetime %thread"));
     EXPECT_EQ(ELPP_LITERAL("%logger %level-%vlevel %datetime %thread"), defaultFormat4.userFormat());
     EXPECT_EQ(ELPP_LITERAL("%logger VER-%vlevel %datetime %thread"), defaultFormat4.format());
-    EXPECT_EQ("%d/%M/%Y %H:%m:%s,%g", defaultFormat4.dateTimeFormat());
+    EXPECT_EQ("%Y-%M-%d %H:%m:%s,%g", defaultFormat4.dateTimeFormat());
 }
 
 TEST(LogFormatResolutionTest, EscapedFormat) {

--- a/test/typed-configurations-test.h
+++ b/test/typed-configurations-test.h
@@ -37,7 +37,7 @@ TEST(TypedConfigurationsTest, Initialization) {
 
     EXPECT_EQ(ELPP_LITERAL("%datetime %level %msg"), tConf.logFormat(Level::Info).userFormat());
     EXPECT_EQ(ELPP_LITERAL("%datetime INFO  %msg"), tConf.logFormat(Level::Info).format());
-    EXPECT_EQ("%d/%M/%Y %H:%m:%s,%g", tConf.logFormat(Level::Info).dateTimeFormat());
+    EXPECT_EQ("%Y-%M-%d %H:%m:%s,%g", tConf.logFormat(Level::Info).dateTimeFormat());
 
     EXPECT_EQ(ELPP_LITERAL("%datetime %%level %level [%user@%%host] [%func] [%loc] %msg"), tConf.logFormat(Level::Debug).userFormat());
     std::string expected = BUILD_STR("%datetime %level DEBUG [" << s_currentUser << "@%%host] [%func] [%loc] %msg");
@@ -47,12 +47,12 @@ TEST(TypedConfigurationsTest, Initialization) {
     const char* orig = tConf.logFormat(Level::Debug).format().c_str();
 #endif
     EXPECT_EQ(expected, std::string(orig));
-    EXPECT_EQ("%d/%M/%Y %H:%m:%s,%g", tConf.logFormat(Level::Debug).dateTimeFormat());
+    EXPECT_EQ("%Y-%M-%d %H:%m:%s,%g", tConf.logFormat(Level::Debug).dateTimeFormat());
 
     // This double quote is escaped at run-time for %date and %datetime
     EXPECT_EQ(ELPP_LITERAL("%datetime %%datetime{%H:%m} %level %msg"), tConf.logFormat(Level::Fatal).userFormat());
     EXPECT_EQ(ELPP_LITERAL("%datetime %%datetime{%H:%m} FATAL %msg"), tConf.logFormat(Level::Fatal).format());
-    EXPECT_EQ("%d/%M/%Y %H:%m:%s,%g", tConf.logFormat(Level::Fatal).dateTimeFormat());
+    EXPECT_EQ("%Y-%M-%d %H:%m:%s,%g", tConf.logFormat(Level::Fatal).dateTimeFormat());
 
     EXPECT_EQ(ELPP_LITERAL("%datetime{%h:%m} %%level %level [%func] [%loc] %msg"), tConf.logFormat(Level::Trace).userFormat());
     EXPECT_EQ(ELPP_LITERAL("%datetime %level TRACE [%func] [%loc] %msg"), tConf.logFormat(Level::Trace).format());
@@ -60,7 +60,7 @@ TEST(TypedConfigurationsTest, Initialization) {
 
     EXPECT_EQ(ELPP_LITERAL("%%datetime{%h:%m} %datetime %level-%vlevel %msg"), tConf.logFormat(Level::Verbose).userFormat());
     EXPECT_EQ(ELPP_LITERAL("%%datetime{%h:%m} %datetime VER-%vlevel %msg"), tConf.logFormat(Level::Verbose).format());
-    EXPECT_EQ("%d/%M/%Y %H:%m:%s,%g", tConf.logFormat(Level::Verbose).dateTimeFormat());
+    EXPECT_EQ("%Y-%M-%d %H:%m:%s,%g", tConf.logFormat(Level::Verbose).dateTimeFormat());
 
     EXPECT_EQ(ELPP_LITERAL("%%logger %%logger %logger %%logger %msg"), tConf.logFormat(Level::Error).userFormat());
     EXPECT_EQ(ELPP_LITERAL("%%logger %%logger %logger %logger %msg"), tConf.logFormat(Level::Error).format());


### PR DESCRIPTION
# Default formatting of date in ISO 8601 Format

This changes the default time/date from %d/%M/%Y to the internet standard for ISO8601 of %Y-%M-%d.  This is in response to [https://github.com/easylogging/easyloggingpp/issues/200](https://github.com/easylogging/easyloggingpp/issues/200).
