### PR TITLE
Patched it to work with mingw cross compiling

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -310,7 +310,7 @@
 #   include <sys/time.h>
 #elif _ELPP_OS_WINDOWS
 #   include <direct.h>
-#   include <Windows.h>
+#   include <windows.h>
 #   if defined(WIN32_LEAN_AND_MEAN)
 #      include <winsock.h>
 #   endif // defined(WIN32_LEAN_AND_MEAN)


### PR DESCRIPTION
On linux systems, mingw comes with lower case windows.h. As opposed to windows, linux has case sensitive paths.
