### PR TITLE
WARN/ERROR/FATAL on standard output should go to cerr and not cout

### DIFF
--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -61,6 +61,7 @@ static const base::type::char_t* kCurrentUserFormatSpecifier      =      ELPP_LI
 static const base::type::char_t* kCurrentHostFormatSpecifier      =      ELPP_LITERAL("%host");
 static const base::type::char_t* kMessageFormatSpecifier          =      ELPP_LITERAL("%msg");
 static const base::type::char_t* kVerboseLevelFormatSpecifier     =      ELPP_LITERAL("%vlevel");
+static const base::type::char_t* kNoNewLineFormatSpecifier        =      ELPP_LITERAL("%nnl");
 static const char* kDateTimeFormatSpecifierForFilename            =      "%datetime";
 // Date/time
 static const char* kDays[7]                         =      { "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" };
@@ -1522,6 +1523,7 @@ void LogFormat::parseFromFormat(const base::type::string_t& userFormat) {
   conditionalAddFlag(base::consts::kCurrentHostFormatSpecifier, base::FormatFlags::Host);
   conditionalAddFlag(base::consts::kMessageFormatSpecifier, base::FormatFlags::LogMessage);
   conditionalAddFlag(base::consts::kVerboseLevelFormatSpecifier, base::FormatFlags::VerboseLevel);
+  conditionalAddFlag(base::consts::kNoNewLineFormatSpecifier, base::FormatFlags::NoNewLine);
   // For date/time we need to extract user's date format first
   std::size_t dateIndex = std::string::npos;
   if ((dateIndex = formatCopy.find(base::consts::kDateTimeFormatSpecifier)) != std::string::npos) {
@@ -2460,7 +2462,13 @@ base::type::string_t DefaultLogBuilder::build(const LogMessage* logMessage, bool
     base::utils::Str::replaceFirstWithEscape(logLine, wcsFormatSpecifier, it->resolver()(logMessage));
   }
 #endif  // !defined(ELPP_DISABLE_CUSTOM_FORMAT_SPECIFIERS)
-  if (appendNewLine) logLine += ELPP_LITERAL("\n");
+  if (appendNewLine) {
+    if (!logFormat->hasFlag(base::FormatFlags::NoNewLine)) {
+      logLine += ELPP_LITERAL("\n");
+    } else {
+      base::utils::Str::replaceAll(logLine, base::consts::kNoNewLineFormatSpecifier, "");
+    }
+  }
   return logLine;
 }
 

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -819,7 +819,8 @@ enum class FormatFlags : base::type::EnumType {
   ThreadId = 1 << 12,
   Level = 1 << 13,
   FileBase = 1 << 14,
-  LevelShort = 1 << 15
+  LevelShort = 1 << 15,
+  NoNewLine = 1 << 16
 };
 /// @brief A subsecond precision class containing actual width and offset of the subsecond part
 class SubsecondPrecision {


### PR DESCRIPTION
### This is a

- [ ] Breaking change
- [ ] New feature
- [x] Bugfix

### I have

- [x] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)
