### PR TITLE
Fixing Readme for the right CustomFormatSpecifier signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Please note, date/time is limited to `30` characters at most.
 You can also specify your own format specifiers. In order to do that you can use `el::Helpers::installCustomFormatSpecifier`. A perfect example is `%ip_addr` for TCP server application;
 
 ```C++
-const char* getIp(void) {
+const char* getIp(const el::LogMessage*) {
     return "192.168.1.1";
 }
 


### PR DESCRIPTION
The README has a minor error regading the function signature to be used by ```CustomFormatSpecifier```, it seems that the function should have ```const el::LogMessage*``` as a parameter.

Just a minor README update.