### PR TITLE
Fix using invalid dateIndex (std::string::npos)

### DIFF
--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -1524,7 +1524,7 @@ void LogFormat::parseFromFormat(const base::type::string_t& userFormat) {
   // For date/time we need to extract user's date format first
   std::size_t dateIndex = std::string::npos;
   if ((dateIndex = formatCopy.find(base::consts::kDateTimeFormatSpecifier)) != std::string::npos) {
-    while (dateIndex > 0 && formatCopy[dateIndex - 1] == base::consts::kFormatSpecifierChar) {
+    while (dateIndex != std::string::npos && dateIndex > 0 && formatCopy[dateIndex - 1] == base::consts::kFormatSpecifierChar) {
       dateIndex = formatCopy.find(base::consts::kDateTimeFormatSpecifier, dateIndex + 1);
     }
     if (dateIndex != std::string::npos) {


### PR DESCRIPTION
Fixes a crash in the tests

### This is a

- [ ] Breaking change
- [ ] New feature
- [x] Bugfix

### I have

- [ x] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ x] [Run the tests](README.md#install-optional)
