### PR TITLE
Add if defined EXECINFO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ endmacro()
 option(test "Build all tests" OFF)
 option(build_static_lib "Build easyloggingpp as a static library" OFF)
 option(lib_utc_datetime "Build library with UTC date/time logging" OFF)
+option(ENABLE_EXECINFO "Enable libexecinfo" OFF)
 
 set(ELPP_MAJOR_VERSION "9")
 set(ELPP_MINOR_VERSION "96")
@@ -95,4 +96,7 @@ if (test)
     target_link_libraries(easyloggingpp-unit-tests gtest gtest_main)
 
     add_test(NAME easyloggingppUnitTests COMMAND easyloggingpp-unit-tests -v)
+endif()
+if (ENABLE_EXECINFO)
+	SET_CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -DENABLE_EXECINFO"
 endif()

--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -2786,7 +2786,7 @@ std::ostream& operator<<(std::ostream& os, const StackTrace& st) {
 }
 
 void StackTrace::generateNew(void) {
-#if ELPP_STACKTRACE
+#if ELPP_STACKTRACE && ENABLE_EXECINFO
   m_stack.clear();
   void* stack[kMaxStack];
   unsigned int size = backtrace(stack, kMaxStack);

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -362,7 +362,9 @@ ELPP_INTERNAL_DEBUGGING_OUT_INFO << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStre
 #endif  // defined(ELPP_UNICODE)
 #if ELPP_STACKTRACE
 #   include <cxxabi.h>
+#if ENABLE_EXECINFO
 #   include <execinfo.h>
+#endif // ENABLE_EXECINFO
 #endif  // ELPP_STACKTRACE
 #if ELPP_OS_ANDROID
 #   include <sys/system_properties.h>


### PR DESCRIPTION
I have submitted a patch at https://github.com/MisterTea/EternalTerminal/pull/269 to support this change there and also added here.
MUSL libc does not natively have libexecinfo. Adding this change,
makes execinfo optional

Signed-off-by: Nathan Owens <ndowens04@gmail.com>

### This is a

- [X] New feature

### I have

- [X] Merged in the latest upstream changes
- [ ] [Run the tests](README.md#install-optional)
