### PR TITLE
Add if defined EXECINFO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,12 @@ configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/cmake/easyloggingpp.pc.cmakein
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/easyloggingpp.pc DESTINATION "${ELPP_PKGCONFIG_INSTALL_DIR}")
 
+include(CheckIncludeFileCXX)
+check_include_file_cxx("execinfo.h" HAVE_EXECINFO)
+if (HAVE_EXECINFO)
+	add_definitions(-DHAVE_EXECINFO)
+endif()
+
 if (build_static_lib)
         if (lib_utc_datetime)
                 add_definitions(-DELPP_UTC_DATETIME)

--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -2786,7 +2786,7 @@ std::ostream& operator<<(std::ostream& os, const StackTrace& st) {
 }
 
 void StackTrace::generateNew(void) {
-#if ELPP_STACKTRACE
+#ifdef HAVE_EXECINFO
   m_stack.clear();
   void* stack[kMaxStack];
   unsigned int size = backtrace(stack, kMaxStack);

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -360,10 +360,10 @@ ELPP_INTERNAL_DEBUGGING_OUT_INFO << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStre
 #      include <codecvt>
 #  endif // ELPP_OS_WINDOWS
 #endif  // defined(ELPP_UNICODE)
-#if ELPP_STACKTRACE
+#ifdef HAVE_EXECINFO
 #   include <cxxabi.h>
 #   include <execinfo.h>
-#endif  // ELPP_STACKTRACE
+#endif // ENABLE_EXECINFO
 #if ELPP_OS_ANDROID
 #   include <sys/system_properties.h>
 #endif  // ELPP_OS_ANDROID


### PR DESCRIPTION
MUSL libc does not natively have libexecinfo. Adding this change,
make execinfo optional. Also made a PR https://github.com/MisterTea/EternalTerminal/pull/269 that uses this as part of their dependencies. So this would make a complete set if both PRs get merged.

Signed-off-by: Nathan Owens <ndowens04@gmail.com>

### This is a

- [x] New feature


### I have

- [x] Merged in the latest upstream changes
- [x] Tested
