### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,17 @@ Following options are supported by Easylogging++ cmake and you can turn these op
 
 With that said, you will still need `easylogging++.cc` file in order to compile. For header only, please check [v9.89](https://github.com/amrayn/easyloggingpp/releases/tag/9.89) and lower.
 
+Alternatively, you can download and install easyloggingpp using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install easyloggingpp
+
+The easyloggingpp port in vcpkg is kept up to date by Microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
  [![top] Goto Top](#table-of-contents)
 
 ### Setting Application Arguments


### PR DESCRIPTION
Easyloggingpp is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build easyloggingpp, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for easyloggingpp and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.