### PR TITLE
bug - access attempt to released memory

### DIFF
--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -599,7 +599,7 @@ void LogBuilder::convertToColoredOutput(base::type::string_t* logLine, Level lev
 
 // Logger
 
-Logger::Logger(const std::string& id, base::LogStreamsReferenceMap* logStreamsReference) :
+Logger::Logger(const std::string& id, base::LogStreamsReferenceMapPtr logStreamsReference) :
   m_id(id),
   m_typedConfigurations(nullptr),
   m_parentApplicationName(std::string()),
@@ -609,7 +609,7 @@ Logger::Logger(const std::string& id, base::LogStreamsReferenceMap* logStreamsRe
 }
 
 Logger::Logger(const std::string& id, const Configurations& configurations,
-               base::LogStreamsReferenceMap* logStreamsReference) :
+               base::LogStreamsReferenceMapPtr logStreamsReference) :
   m_id(id),
   m_typedConfigurations(nullptr),
   m_parentApplicationName(std::string()),
@@ -1615,7 +1615,7 @@ void LogFormat::updateFormatSpec(void) {
 // TypedConfigurations
 
 TypedConfigurations::TypedConfigurations(Configurations* configurations,
-    base::LogStreamsReferenceMap* logStreamsReference) {
+    LogStreamsReferenceMapPtr logStreamsReference) {
   m_configurations = configurations;
   m_logStreamsReference = logStreamsReference;
   build(m_configurations);
@@ -1885,6 +1885,7 @@ bool RegisteredHitCounters::validateNTimes(const char* filename, base::type::Lin
 RegisteredLoggers::RegisteredLoggers(const LogBuilderPtr& defaultLogBuilder) :
   m_defaultLogBuilder(defaultLogBuilder) {
   m_defaultConfigurations.setToDefault();
+  m_logStreamsReference = std::make_shared<base::LogStreamsReferenceMap>();
 }
 
 Logger* RegisteredLoggers::get(const std::string& id, bool forceCreation) {
@@ -1896,7 +1897,7 @@ Logger* RegisteredLoggers::get(const std::string& id, bool forceCreation) {
       ELPP_ASSERT(validId, "Invalid logger ID [" << id << "]. Not registering this logger.");
       return nullptr;
     }
-    logger_ = new Logger(id, m_defaultConfigurations, &m_logStreamsReference);
+    logger_ = new Logger(id, m_defaultConfigurations, m_logStreamsReference);
     logger_->m_logBuilder = m_defaultLogBuilder;
     registerNew(id, logger_);
     LoggerRegistrationCallback* callback = nullptr;
@@ -1926,8 +1927,8 @@ bool RegisteredLoggers::remove(const std::string& id) {
 
 void RegisteredLoggers::unsafeFlushAll(void) {
   ELPP_INTERNAL_INFO(1, "Flushing all log files");
-  for (base::LogStreamsReferenceMap::iterator it = m_logStreamsReference.begin();
-       it != m_logStreamsReference.end(); ++it) {
+  for (base::LogStreamsReferenceMap::iterator it = m_logStreamsReference->begin();
+       it != m_logStreamsReference->end(); ++it) {
     if (it->second.get() == nullptr) continue;
     it->second->flush();
   }
@@ -3005,7 +3006,7 @@ const Configurations* Loggers::defaultConfigurations(void) {
   return ELPP->registeredLoggers()->defaultConfigurations();
 }
 
-const base::LogStreamsReferenceMap* Loggers::logStreamsReference(void) {
+const base::LogStreamsReferenceMapPtr Loggers::logStreamsReference(void) {
   return ELPP->registeredLoggers()->logStreamsReference();
 }
 

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -1893,6 +1893,7 @@ class Configurations : public base::utils::RegistryWithPred<Configuration, Confi
 namespace base {
 typedef std::shared_ptr<base::type::fstream_t> FileStreamPtr;
 typedef std::unordered_map<std::string, FileStreamPtr> LogStreamsReferenceMap;
+typedef std::shared_ptr<base::LogStreamsReferenceMap> LogStreamsReferenceMapPtr;
 /// @brief Configurations with data types.
 ///
 /// @detail el::Configurations have string based values. This is whats used internally in order to read correct configurations.
@@ -1904,7 +1905,7 @@ class TypedConfigurations : public base::threading::ThreadSafe {
   /// @brief Constructor to initialize (construct) the object off el::Configurations
   /// @param configurations Configurations pointer/reference to base this typed configurations off.
   /// @param logStreamsReference Use ELPP->registeredLoggers()->logStreamsReference()
-  TypedConfigurations(Configurations* configurations, base::LogStreamsReferenceMap* logStreamsReference);
+  TypedConfigurations(Configurations* configurations, LogStreamsReferenceMapPtr logStreamsReference);
 
   TypedConfigurations(const TypedConfigurations& other);
 
@@ -1939,7 +1940,7 @@ class TypedConfigurations : public base::threading::ThreadSafe {
   std::unordered_map<Level, base::FileStreamPtr> m_fileStreamMap;
   std::unordered_map<Level, std::size_t> m_maxLogFileSizeMap;
   std::unordered_map<Level, std::size_t> m_logFlushThresholdMap;
-  base::LogStreamsReferenceMap* m_logStreamsReference;
+  LogStreamsReferenceMapPtr m_logStreamsReference = nullptr;
 
   friend class el::Helpers;
   friend class el::base::MessageBuilder;
@@ -2210,8 +2211,8 @@ typedef std::shared_ptr<LogBuilder> LogBuilderPtr;
 /// @detail This class does not write logs itself instead its used by writer to read configuations from.
 class Logger : public base::threading::ThreadSafe, public Loggable {
  public:
-  Logger(const std::string& id, base::LogStreamsReferenceMap* logStreamsReference);
-  Logger(const std::string& id, const Configurations& configurations, base::LogStreamsReferenceMap* logStreamsReference);
+  Logger(const std::string& id, base::LogStreamsReferenceMapPtr logStreamsReference);
+  Logger(const std::string& id, const Configurations& configurations, base::LogStreamsReferenceMapPtr logStreamsReference);
   Logger(const Logger& logger);
   Logger& operator=(const Logger& logger);
 
@@ -2301,7 +2302,7 @@ inline void FUNCTION_NAME(const T&);
   bool m_isConfigured;
   Configurations m_configurations;
   std::unordered_map<Level, unsigned int> m_unflushedCount;
-  base::LogStreamsReferenceMap* m_logStreamsReference;
+  base::LogStreamsReferenceMapPtr m_logStreamsReference = nullptr;
   LogBuilderPtr m_logBuilder;
 
   friend class el::LogMessage;
@@ -2388,8 +2389,8 @@ class RegisteredLoggers : public base::utils::Registry<Logger, std::string> {
     base::utils::Registry<Logger, std::string>::unregister(logger->id());
   }
 
-  inline base::LogStreamsReferenceMap* logStreamsReference(void) {
-    return &m_logStreamsReference;
+  inline LogStreamsReferenceMapPtr logStreamsReference(void) {
+    return m_logStreamsReference;
   }
 
   inline void flushAll(void) {
@@ -2405,7 +2406,7 @@ class RegisteredLoggers : public base::utils::Registry<Logger, std::string> {
  private:
   LogBuilderPtr m_defaultLogBuilder;
   Configurations m_defaultConfigurations;
-  base::LogStreamsReferenceMap m_logStreamsReference;
+  base::LogStreamsReferenceMapPtr m_logStreamsReference = nullptr;
   std::unordered_map<std::string, base::type::LoggerRegistrationCallbackPtr> m_loggerRegistrationCallbacks;
   friend class el::base::Storage;
 
@@ -3824,7 +3825,7 @@ class Loggers : base::StaticClass {
   /// @brief Returns current default
   static const Configurations* defaultConfigurations(void);
   /// @brief Returns log stream reference pointer if needed by user
-  static const base::LogStreamsReferenceMap* logStreamsReference(void);
+  static const base::LogStreamsReferenceMapPtr logStreamsReference(void);
   /// @brief Default typed configuration based on existing defaultConf
   static base::TypedConfigurations defaultTypedConfigurations(void);
   /// @brief Populates all logger IDs in current repository.
@@ -3835,7 +3836,7 @@ class Loggers : base::StaticClass {
   /// @brief Configures loggers using command line arg. Ensure you have already set command line args,
   /// @return False if invalid argument or argument with no value provided, true if attempted to configure logger.
   ///         If true is returned that does not mean it has been configured successfully, it only means that it
-  ///         has attempeted to configure logger using configuration file provided in argument
+  ///         has attempted to configure logger using configuration file provided in argument
   static bool configureFromArg(const char* argKey);
   /// @brief Flushes all loggers for all levels - Be careful if you dont know how many loggers are registered
   static void flushAll(void);


### PR DESCRIPTION
On the UGW platform, a SIGSEGV event is sent to a prplmesh application
that utilizes the easylogging++ library. The event is sent due to an
access attempt to a released memory. The released memory is a pointer
to the "LogStreamsReferenceMap m_logStreamsReference" which is defined
statically in RegisteredLoggers class.

The RegisteredLoggers object is released in UGW before the release of
other Class objects that make use of the pointer, and thus - the pointer is accessed
after the map is already released.

The issue may be seen in other platforms and is dependent on the difference in object release order.

After this change, the map is defined as a shared-pointer in the RegisteredLoggers class
and is set to a shared-pointer of type LogStreamsReferenceMap in the RegisteredLoggers CTOR. Even if the RegisteredLoggers object is released, the map resource will be
available to the rest of the objects until all are destructed.

### This is a

- [ ] Breaking change
- [ ] New feature
- [x] Bugfix

### I have

- [x] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)

Fixes #738 