### PR TITLE
kSysLogLoggerId defined but not used

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -3632,6 +3632,7 @@ class SysLogInitializer {
  public:
   SysLogInitializer(const char* processIdent, int options = 0, int facility = 0) {
 #if defined(ELPP_SYSLOG)
+    (void)base::consts::kSysLogLoggerId;
     openlog(processIdent, options, facility);
 #else
     ELPP_UNUSED(processIdent);


### PR DESCRIPTION
Hi,

This PR follows #620 and https://github.com/amrayn/easyloggingpp/commit/b96d4895fb3dee44be16d5ab9dd98fcfee49bd30, and fixes the following warning :
```
‘el::base::consts::kSysLogLoggerId’ defined but not used [-Wunused-variable]
783 static const char* kSysLogLoggerId                         =      "syslog";
```

It then closes #742.

Thank you 👍