### PR TITLE
Adds support for easyloggingpp to log WARNING, ERROR, and FATAL to standard error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [9.96.8] - 02-09-2020
+- Adds support for easyloggingpp to log WARNING, ERROR, and FATAL to standard error. this befaviour can be reverted to old behaviour by defining `#define ELPP_CUSTOM_CERR std::cout`. this provides the the ability for CHECK macros and application abortion messages to be written to standard error instead of standard output. this is required in order for DEATH_TEST macro's in google test to match against easyloggingpp output, for example, `ASSERT_DEATH({CHECK_EQ(1, 2) << "error: value_a is not equal to value_b"; }, ".*value_a is not equal to value_b");`
+
 ## [9.96.7] - 24-11-2018
 - Adds support for compiling easyloggingpp using Emscripten. This allows the library to be compiled into Javascript or WebAssembly and run in the browser while logging to the browser's Javascript console.
 

--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ Some of logging options can be set by macros, this is a thoughtful decision, for
 | `ELPP_DISABLE_LOG_FILE_FROM_ARG`        | Forcefully disables ability to set default log file from command-line arguments                                                                    |
 | `ELPP_WINSOCK2`        | On windows system force to use `winsock2.h` instead of `winsock.h` when `WIN32_LEAN_AND_MEAN` is defined                                                                    |
 | `ELPP_CUSTOM_COUT` (advanced)     | Resolves to a value e.g, `#define ELPP_CUSTOM_COUT qDebug()` or `#define ELPP_CUSTOM_COUT std::cerr`. This will use the value for standard output (instead of using `std::cout`|
+| `ELPP_CUSTOM_CERR` (advanced)     | Resolves to a value e.g, `#define ELPP_CUSTOM_CERR qDebug()` or `#define ELPP_CUSTOM_CERR std::cout`. This will use the value for standard output (instead of using `std::cerr`|
 | `ELPP_CUSTOM_COUT_LINE` (advanced) | Used with `ELPP_CUSTOM_COUT` to define how to write a log line with custom cout. e.g, `#define ELPP_CUSTOM_COUT_LINE(msg) QString::fromStdString(msg).trimmed()` |
 | `ELPP_NO_CHECK_MACROS`             | Do not define the *CHECK* macros                                                                                                                  |
 | `ELPP_NO_DEBUG_MACROS`             | Do not define the *DEBUG* macros                                                                                                                  |

--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -2240,7 +2240,8 @@ void DefaultLogDispatchCallback::dispatch(base::type::string_t&& logLine) {
     if (m_data->logMessage()->logger()->m_typedConfigurations->toStandardOutput(m_data->logMessage()->level())) {
       if (ELPP->hasFlag(LoggingFlag::ColoredTerminalOutput))
         m_data->logMessage()->logger()->logBuilder()->convertToColoredOutput(&logLine, m_data->logMessage()->level());
-      ELPP_COUT << ELPP_COUT_LINE(logLine);
+      if (m_data->logMessage()->level() == Level::Warning || m_data->logMessage()->level() == Level::Error || m_data->logMessage()->level() == Level::Fatal) ELPP_CERR << ELPP_COUT_LINE(logLine);
+      else ELPP_COUT << ELPP_COUT_LINE(logLine);
     }
   }
 #if defined(ELPP_SYSLOG)
@@ -2281,10 +2282,11 @@ void AsyncLogDispatchCallback::handle(const LogDispatchData* data) {
       && data->logMessage()->logger()->typedConfigurations()->toStandardOutput(data->logMessage()->level())) {
     if (ELPP->hasFlag(LoggingFlag::ColoredTerminalOutput))
       data->logMessage()->logger()->logBuilder()->convertToColoredOutput(&logLine, data->logMessage()->level());
-    ELPP_COUT << ELPP_COUT_LINE(logLine);
+    if (data->logMessage()->level() == Level::Warning || data->logMessage()->level() == Level::Error || data->logMessage()->level() == Level::Fatal) ELPP_CERR << ELPP_COUT_LINE(logLine);
+    else ELPP_COUT << ELPP_COUT_LINE(logLine);
   }
   // Save resources and only queue if we want to write to file otherwise just ignore handler
-  if (data->logMessage()->logger()->typedConfigurations()->toFile(data->logMessage()->level())) {
+  if (data->logMessage()->logger()->typedConfigurations()->toFile(level)) {
     ELPP->asyncLogQueue()->push(AsyncLogItem(*(data->logMessage()), *data, logLine));
   }
 }

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -503,6 +503,7 @@ namespace type {
 #undef ELPP_LITERAL
 #undef ELPP_STRLEN
 #undef ELPP_COUT
+#undef ELPP_CERR
 #if defined(ELPP_UNICODE)
 #  define ELPP_LITERAL(txt) L##txt
 #  define ELPP_STRLEN wcslen
@@ -511,6 +512,11 @@ namespace type {
 #  else
 #    define ELPP_COUT std::wcout
 #  endif  // defined ELPP_CUSTOM_COUT
+#  if defined ELPP_CUSTOM_CERR
+#    define ELPP_CERR ELPP_CUSTOM_CERR
+#  else
+#    define ELPP_CERR std::wcerr
+#  endif  // defined ELPP_CUSTOM_CERR
 typedef wchar_t char_t;
 typedef std::wstring string_t;
 typedef std::wstringstream stringstream_t;
@@ -524,6 +530,11 @@ typedef std::wostream ostream_t;
 #  else
 #    define ELPP_COUT std::cout
 #  endif  // defined ELPP_CUSTOM_COUT
+#  if defined ELPP_CUSTOM_CERR
+#    define ELPP_CERR ELPP_CUSTOM_CERR
+#  else
+#    define ELPP_CERR std::cerr
+#  endif  // defined ELPP_CUSTOM_CERR
 typedef char char_t;
 typedef std::string string_t;
 typedef std::stringstream stringstream_t;


### PR DESCRIPTION
### This is a

- [ ] Breaking change
- [ * ] New feature
- [ * ] Bugfix

### I have

- [ ] Merged in the latest upstream changes
- [ * ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ * ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)
```
[100%] Linking CXX executable easyloggingpp-unit-tests
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): in function `testing::internal::ThreadLocal<std::vector<testing::internal::TraceInfo, std::allocator<testing::internal::TraceInfo> > >::~ThreadLocal()':
./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1750: undefined reference to `pthread_getspecific'
/usr/bin/ld: ./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1754: undefined reference to `pthread_key_delete'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): in function `testing::internal::ThreadLocal<testing::TestPartResultReporterInterface*>::~ThreadLocal()':
./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1750: undefined reference to `pthread_getspecific'
/usr/bin/ld: ./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1754: undefined reference to `pthread_key_delete'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): in function `testing::internal::ThreadLocal<std::vector<testing::internal::TraceInfo, std::allocator<testing::internal::TraceInfo> > >::GetOrCreateValue() const':
./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1787: undefined reference to `pthread_getspecific'
/usr/bin/ld: ./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1794: undefined reference to `pthread_setspecific'
/usr/bin/ld: ./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1787: undefined reference to `pthread_getspecific'
/usr/bin/ld: ./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1794: undefined reference to `pthread_setspecific'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): in function `testing::internal::ThreadLocal<testing::TestPartResultReporterInterface*>::CreateKey()':
./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1780: undefined reference to `pthread_key_create'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): in function `testing::internal::ThreadLocal<std::vector<testing::internal::TraceInfo, std::allocator<testing::internal::TraceInfo> > >::CreateKey()':
./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1780: undefined reference to `pthread_key_create'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): in function `testing::internal::ThreadLocal<testing::TestPartResultReporterInterface*>::GetOrCreateValue() const':
./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1787: undefined reference to `pthread_getspecific'
/usr/bin/ld: ./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1794: undefined reference to `pthread_setspecific'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): in function `testing::internal::ThreadLocal<std::vector<testing::internal::TraceInfo, std::allocator<testing::internal::TraceInfo> > >::GetOrCreateValue() const':
./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1787: undefined reference to `pthread_getspecific'
/usr/bin/ld: ./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1787: undefined reference to `pthread_getspecific'
/usr/bin/ld: ./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1794: undefined reference to `pthread_setspecific'
/usr/bin/ld: ./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1794: undefined reference to `pthread_setspecific'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): in function `testing::internal::ThreadLocal<testing::TestPartResultReporterInterface*>::GetOrCreateValue() const':
./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1787: undefined reference to `pthread_getspecific'
/usr/bin/ld: ./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1794: undefined reference to `pthread_setspecific'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): in function `testing::internal::ThreadLocal<std::vector<testing::internal::TraceInfo, std::allocator<testing::internal::TraceInfo> > >::~ThreadLocal()':
./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1750: undefined reference to `pthread_getspecific'
/usr/bin/ld: ./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1754: undefined reference to `pthread_key_delete'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): in function `testing::internal::ThreadLocal<testing::TestPartResultReporterInterface*>::~ThreadLocal()':
./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1750: undefined reference to `pthread_getspecific'
/usr/bin/ld: ./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1754: undefined reference to `pthread_key_delete'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../x86_64-linux-gnu/libgtest.a(gtest-all.cc.o): in function `testing::internal::ThreadLocal<std::vector<testing::internal::TraceInfo, std::allocator<testing::internal::TraceInfo> > >::GetOrCreateValue() const':
./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1787: undefined reference to `pthread_getspecific'
/usr/bin/ld: ./obj-x86_64-linux-gnu/googletest/./googletest/include/gtest/internal/gtest-port.h:1794: undefined reference to `pthread_setspecific'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/easyloggingpp-unit-tests.dir/build.make:99: easyloggingpp-unit-tests] Error 1
make[1]: *** [CMakeFiles/Makefile2:76: CMakeFiles/easyloggingpp-unit-tests.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```
