### PR TITLE
Fix a warning: 'ex' unreferenced local variable

### DIFF
--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -2654,7 +2654,7 @@ void Writer::triggerDispatch(void) {
 	  }
 	  m_proceed = false;
 	  }
-	catch(std::exception & ex){
+	catch(std::exception & /*ex*/){
 		// Extremely low memory situation; don't let exception be unhandled.
 	}
 }


### PR DESCRIPTION
### This is a
- [x] Bugfix

### I have
- [x] [Run the tests](README.md#install-optional)

After I updated easylogging from v9.96.7 to v9.97.0, this code:
	catch(std::exception & ex){
		// Extremely low memory situation; don't let exception be unhandled.
	}
will generate a warning:
warning C4101: 'ex': unreferenced local variable
and our build will fail.