### PR TITLE
Update version to 9.97.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,8 @@ option(build_static_lib "Build easyloggingpp as a static library" OFF)
 option(lib_utc_datetime "Build library with UTC date/time logging" OFF)
 
 set(ELPP_MAJOR_VERSION "9")
-set(ELPP_MINOR_VERSION "96")
-set(ELPP_PATCH_VERSION "7")
+set(ELPP_MINOR_VERSION "97")
+set(ELPP_PATCH_VERSION "0")
 set(ELPP_VERSION_STRING "${ELPP_MAJOR_VERSION}.${ELPP_MINOR_VERSION}.${ELPP_PATCH_VERSION}")
 
 set(ELPP_INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "The directory the headers are installed in")

--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -1,7 +1,7 @@
 //
 //  Bismillah ar-Rahmaan ar-Raheem
 //
-//  Easylogging++ v9.96.7
+//  Easylogging++ v9.97.0
 //  Cross-platform logging library for C++ applications
 //
 //  Copyright (c) 2012-2018 Amrayn Web Services
@@ -3110,7 +3110,7 @@ void Loggers::clearVModules(void) {
 // VersionInfo
 
 const std::string VersionInfo::version(void) {
-  return std::string("9.96.7");
+  return std::string("9.97.0");
 }
 /// @brief Release date of current version
 const std::string VersionInfo::releaseDate(void) {

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -1,7 +1,7 @@
 //
 //  Bismillah ar-Rahmaan ar-Raheem
 //
-//  Easylogging++ v9.96.7
+//  Easylogging++ v9.97.0
 //  Single-header only, cross-platform logging library for C++ applications
 //
 //  Copyright (c) 2012-2018 Amrayn Web Services


### PR DESCRIPTION
For some reason the latest version is 9.97.0 but it was never updated in the code.

### This is a

- [ ] Breaking change
- [ ] New feature
- [X] Bugfix

### I have

- [X] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)
