### PR TITLE
Add strict permissions flag

### DIFF
--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -745,6 +745,13 @@ base::type::fstream_t* File::newFileStream(const std::string& filename) {
 #endif  // defined(ELPP_UNICODE)
   if (fs->is_open()) {
     fs->flush();
+#if defined(ELPP_STRICT_PERMISSIONS)
+    if (filename != "/dev/null" && filename != "nul") {
+      fs::permissions(filename,
+                  fs::perms::owner_read | fs::perms::owner_write | fs::perms::group_read,
+                  fs::perm_options::replace);
+    }
+#endif
   } else {
     base::utils::safeDelete(fs);
     ELPP_INTERNAL_ERROR("Bad file [" << filename << "]", true);

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -461,6 +461,34 @@ ELPP_INTERNAL_DEBUGGING_OUT_INFO << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStre
 // For logging wxWidgets based classes & templates
 #   include <wx/vector.h>
 #endif  // defined(ELPP_WXWIDGETS_LOGGING)
+#if defined(ELPP_STRICT_PERMISSIONS)
+// Need to check for Boost first because Mojave *has* std::filesystem,
+// but won't let you use it.
+#if __APPLE__
+#if __has_include(<boost/filesystem.hpp>)
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
+#else
+#include <filesystem>
+namespace fs = std::filesystem;
+#endif
+#else
+// For non-Apple systems, prefer std::filesystem
+// Otherwise, older versions of boost cause failures.
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental;
+#elif __has_include(<boost/filesystem>)
+#include <boost/filesystem>
+namespace fs = boost::filesystem
+#else
+#pragma message "No filesystem library found."
+#endif
+#endif
+#endif
 #if defined(ELPP_UTC_DATETIME)
 #   define elpptime_r gmtime_r
 #   define elpptime_s gmtime_s


### PR DESCRIPTION
Hey all!  Thanks for creating a beautiful and simple logging library.

We use easyloggingpp in Eternal Terminal ( https://github.com/MisterTea/EternalTerminal ) and would like the logs to only be readable by the user and group that created them (especially for logs created by root).  This PR adds a compile flag for that.

A couple of points:

1. I'm not sure if a compile flag is the right approach, but it looked like creating an option would require us to pass the option all the way down to file creation, which could be a much bigger change.
2. If the flag is on, I try to bring in std::filesystem to ensure that the correct permissions are set on unix and windows.  If this is too large of a footprint, we could do it only for unix.

### This is a

- [ ] Breaking change
- [X] New feature
- [ ] Bugfix

### I have

- [X ] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [X ] [Run the tests](README.md#install-optional)



