### PR TITLE
Fix creation of unnecessary temporary

### DIFF
--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -1901,7 +1901,7 @@ Logger* RegisteredLoggers::get(const std::string& id, bool forceCreation) {
     logger_->m_logBuilder = m_defaultLogBuilder;
     registerNew(id, logger_);
     LoggerRegistrationCallback* callback = nullptr;
-    for (const std::pair<std::string, base::type::LoggerRegistrationCallbackPtr>& h
+    for (const std::pair<const std::string, base::type::LoggerRegistrationCallbackPtr>& h
          : m_loggerRegistrationCallbacks) {
       callback = h.second.get();
       if (callback != nullptr && callback->enabled()) {
@@ -2493,7 +2493,7 @@ void LogDispatcher::dispatch(void) {
   }
   LogDispatchCallback* callback = nullptr;
   LogDispatchData data;
-  for (const std::pair<std::string, base::type::LogDispatchCallbackPtr>& h
+  for (const std::pair<const std::string, base::type::LogDispatchCallbackPtr>& h
        : ELPP->m_logDispatchCallbacks) {
     callback = h.second.get();
     if (callback != nullptr && callback->enabled()) {
@@ -2705,7 +2705,7 @@ PerformanceTracker::~PerformanceTracker(void) {
       data.init(this);
       data.m_formattedTimeTaken = formattedTime;
       PerformanceTrackingCallback* callback = nullptr;
-      for (const std::pair<std::string, base::type::PerformanceTrackingCallbackPtr>& h
+      for (const std::pair<const std::string, base::type::PerformanceTrackingCallbackPtr>& h
            : ELPP->m_performanceTrackingCallbacks) {
         callback = h.second.get();
         if (callback != nullptr && callback->enabled()) {


### PR DESCRIPTION
A reference to a value type of a `std::unordered_map` has a const key
within the corresponding pair. Using a `std::pair<std::string...`
therefore causes the creation of such a pair out of the loop variable.
Clang reports this.

### This is a

- [ ] Breaking change
- [ ] New feature
- [ ] Bugfix
- [ x] Minor code improvement

### I have

- [x ] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)
