### PR TITLE
Convert words.txt from ISO-8859-1 to UTF-8

### DIFF
--- a/samples/Qt/fast-dictionary/words.txt
+++ b/samples/Qt/fast-dictionary/words.txt
@@ -3579,7 +3579,7 @@ applied
 applier
 appliers
 applies
-appliqué
+appliquÃ©
 apply
 applying
 appoint
@@ -13348,8 +13348,8 @@ cleverly
 cleverness
 clevis
 clianthus
-cliché
-clichés
+clichÃ©
+clichÃ©s
 click
 clicked
 clicker
@@ -14587,8 +14587,8 @@ communicator's
 communicatory
 communing
 communion
-communiqué
-communiqués
+communiquÃ©
+communiquÃ©s
 communisation
 communisations
 communisation's
@@ -17464,8 +17464,8 @@ creature
 creaturely
 creatures
 creature's
-crèche
-crèches
+crÃ¨che
+crÃ¨ches
 credence
 credendum
 credent
@@ -19193,7 +19193,7 @@ decollates
 decollating
 decollation
 decollations
-décolletage
+dÃ©colletage
 decolonisation
 decolonise
 decolonised
@@ -19676,7 +19676,7 @@ deistically
 deities
 deity
 deity's
-déjà
+dÃ©jÃ 
 deject
 dejected
 dejectedly
@@ -20792,7 +20792,7 @@ detainee
 detaining
 detainment
 detains
-d'état
+d'Ã©tat
 detect
 detectable
 detectably
@@ -20906,7 +20906,7 @@ detrained
 detraining
 detrainment
 detrains
-d'être
+d'Ãªtre
 detribalisation
 detribalise
 detribalised
@@ -25215,7 +25215,7 @@ emigrated
 emigrates
 emigrating
 emigration
-émigré
+Ã©migrÃ©
 eminence
 eminency
 eminent
@@ -29092,8 +29092,8 @@ feyness
 fez
 fezzes
 fiacre
-fiancé
-fiancée
+fiancÃ©
+fiancÃ©e
 fiasco
 fiat
 fiats
@@ -41678,7 +41678,7 @@ japes
 japing
 japonica
 jar
-jardinière
+jardiniÃ¨re
 jarful
 jargon
 jargonise
@@ -45284,7 +45284,7 @@ mackerel
 mackerels
 mackinaw
 mackintosh
-macramé
+macramÃ©
 macro
 macrobiotic
 macrobiotics
@@ -45799,7 +45799,7 @@ manorial
 manors
 manor's
 manpower
-manqué
+manquÃ©
 manrope
 manropes
 mans
@@ -48083,7 +48083,7 @@ moieties
 moiety
 moil
 moiling
-moiré
+moirÃ©
 moist
 moisten
 moistened
@@ -52885,7 +52885,7 @@ passant
 passbook
 passbooks
 passbook's
-passé
+passÃ©
 passed
 passenger
 passengers
@@ -56054,7 +56054,7 @@ precipitator
 precipitin
 precipitous
 precipitously
-précis
+prÃ©cis
 precise
 precisely
 preciseness
@@ -59313,7 +59313,7 @@ recheck
 rechecked
 rechecking
 rechecks
-recherché
+recherchÃ©
 recidivism
 recidivist
 recidivistic
@@ -66998,7 +66998,7 @@ sot
 sotto
 soubrette
 soubriquet
-soufflé
+soufflÃ©
 sough
 sought
 soul


### PR DESCRIPTION
### This is a

- [ ] Breaking change
- [ ] New feature
- [x] Bugfix

### I have

- [x] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md) (*trivial*)
- [ ] Updated [`README.md`](README.md) (*trivial*)
- [ ] [Run the tests](README.md#install-optional) (*trivial*)

This fixes incorrect display of words using non-ASCII characters in the “Fast Dictionary Sample,” such as “appliqué.”