### PR TITLE
Update easylogging++.h

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -1379,7 +1379,7 @@ class Registry : public AbstractRegistry<T_Ptr, std::unordered_map<T_Key, T_Ptr*
   Registry(void) {}
 
   /// @brief Copy constructor that is useful for base classes. Try to avoid this constructor, use move constructor.
-  Registry(const Registry& sr) : AbstractRegistry<T_Ptr, std::vector<T_Ptr*>>() {
+  Registry(const Registry& sr) : AbstractRegistry<T_Ptr, std::unordered_map<T_Key, T_Ptr*>>() {
     if (this == &sr) {
       return;
     }


### PR DESCRIPTION
fix class Registry copy constructor error

### This is a

- [ ] Breaking change
- [ ] New feature
- [x] Bugfix

### I have

- [x] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)
