### PR TITLE
Added CMake-support for commonly used preprocessor directives.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [9.97.1] - 11-05-2023
+
+### Features
+ * CMake support for flags ELPP_FORCE_USE_STD_THREAD, ELPP_NO_DEFAULT_LOG_FILE and ELPP_THREAD_SAFE
+
 ## [9.97.0] - 25-12-2020
 ### Features
  * Support for QNX OS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ option(test "Build all tests" OFF)
 option(build_static_lib "Build easyloggingpp as a static library" OFF)
 option(lib_utc_datetime "Build library with UTC date/time logging" OFF)
 
+option(no_default_logfile "Do not write to default log file \"myeasylog.log\" (define ELPP_NO_DEFAULT_LOG_FILE)" OFF)
+option(thread_safe "Build easyloggingpp thread safe (define ELPP_THREAD_SAFE)" OFF)
+option(use_std_threads "Use standard library thread synchronization (define ELPP_FORCE_USE_STD_THREAD)" OFF)
+
 set(ELPP_MAJOR_VERSION "9")
 set(ELPP_MINOR_VERSION "96")
 set(ELPP_PATCH_VERSION "7")
@@ -55,6 +59,18 @@ endif()
 if (build_static_lib)
         if (lib_utc_datetime)
                 add_definitions(-DELPP_UTC_DATETIME)
+        endif()
+
+        if (no_default_logfile)
+                add_definitions(-DELPP_NO_DEFAULT_LOG_FILE)
+        endif()
+
+        if (thread_safe)
+                add_definitions(-DELPP_THREAD_SAFE)
+        endif()
+
+        if (use_std_threads)
+                add_definitions(-DELPP_FORCE_USE_STD_THREAD)
         endif()
 
         require_cpp11()


### PR DESCRIPTION
New CMake options:
 - use_std_threads ->ELPP_FORCE_USE_STD_THREAD
 - no_default_logfile -> ELPP_NO_DEFAULT_LOG_FILE
 - thread_safe  -> ELPP_THREAD_SAFE

### This is a

- [ ] Breaking change
- [x] New feature
- [ ] Bugfix

### I have

- [ ] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [x] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)
