### PR TITLE
Update minimum CMake version to 3.12; support CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.12)
 
 project(Easyloggingpp CXX)
 


### PR DESCRIPTION
CMake 4.0 drops support for CMake <3.5, so minimum versions need to be adjusted for forward compatibility. As long as we are touching the minimum version, let’s advance to 3.12, which can be considered the oldest “modern” CMake release, and which is available in all known supported Linux distributions today.

### This is a

- [ ] Breaking change
- [ ] New feature
- [ ] Bugfix

### I have

- [ ] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)
